### PR TITLE
maint: address FIXME comment in va function

### DIFF
--- a/engine/common/common.c
+++ b/engine/common/common.c
@@ -6833,7 +6833,6 @@ va
 
 does a varargs printf into a temp buffer, so I don't need to have
 varargs versions of all text functions.
-FIXME: make this buffer size safe someday
 ============
 */
 char	*VARGS va(const char *format, ...)
@@ -6847,10 +6846,10 @@ char	*VARGS va(const char *format, ...)
 	COM_AssertMainThread("va");
 
 	bufnum++;
-	bufnum &= (VA_BUFFERS-1);
+	bufnum &= (VA_BUFFERS - 1);
 
 	va_start (argptr, format);
-	vsnprintf (string[bufnum],sizeof(string[bufnum])-1, format,argptr);
+	Q_vsnprintfz (string[bufnum], sizeof(string[bufnum]), format, argptr);
 	va_end (argptr);
 
 	return string[bufnum];


### PR DESCRIPTION
What this PR aims to do is basically address the concern that the va() function might be unsafe.
The function va() was already refactored in https://github.com/nzp-team/fteqw/blob/master/plugins/plugin.c#L158 it seems.

I think that by looking at the internals of Q_vsnprintfz, it handles the edge case of buffer overrun perfectly on both Windows and UNIX platforms. Most importantly this function will not hard error has it will always return a null terminated string.